### PR TITLE
[fix](#19): 메인페이지 - 페이지네이션 기능, ui 제외하고 피드백 수정완료

### DIFF
--- a/src/features/lectures/components/main/Categories.tsx
+++ b/src/features/lectures/components/main/Categories.tsx
@@ -16,6 +16,7 @@ export default function Categories({ categories }: Props) {
   const update = (value: string) => {
     const query = new URLSearchParams(searchParams.toString());
     query.set('category', value); //  카테고리만 세팅
+    query.delete('page');
     router.push(`?${query.toString()}`, { scroll: false });
   };
 

--- a/src/features/lectures/components/main/Category.tsx
+++ b/src/features/lectures/components/main/Category.tsx
@@ -11,7 +11,11 @@ interface Props {
 
 export default function Category({ name, selected, onClick }: Props) {
   return (
-    <Button variant={selected ? 'default' : 'secondary'} onClick={onClick}>
+    <Button
+      variant={selected ? 'default' : 'secondary'}
+      onClick={onClick}
+      className="cursor-pointer"
+    >
       {name}
     </Button>
   );

--- a/src/features/lectures/components/main/LevelFilter.tsx
+++ b/src/features/lectures/components/main/LevelFilter.tsx
@@ -18,7 +18,7 @@ export default function LevelFilter() {
   const update = (value: string) => {
     const query = new URLSearchParams(searchParams.toString());
     query.set('level', value);
-    query.delete('page');
+    query.delete('page'); //page를 삭제해서 1페이지로 초기화하는 효과
     router.push(`?${query.toString()}`, { scroll: false });
   };
 

--- a/src/features/lectures/components/main/Sort.tsx
+++ b/src/features/lectures/components/main/Sort.tsx
@@ -16,9 +16,10 @@ export default function Sort() {
   const sort = searchParams.get('sort') || 'POPULAR';
 
   const update = (value: string) => {
-    const params = new URLSearchParams(searchParams.toString());
-    params.set('sort', value);
-    router.push(`?${params.toString()}`, { scroll: false });
+    const query = new URLSearchParams(searchParams.toString());
+    query.set('sort', value);
+    query.delete('page');
+    router.push(`?${query.toString()}`, { scroll: false });
   };
 
   return (


### PR DESCRIPTION
# 목표 
피드백대로 메인페이지 수정
# 상세 작업 목록
- [x]  카테고리acitve ui안됌
- [x]  카테고리, 난이도, 인기순 필터시에 ⇒   페이지네이션:  1로초기화 렌더링
- [x]  레벨필터만 페이지딜리트가 들어가잇는데 sort랑 카테고리에도 delete 넣기
- [ ]  페이지네이션 기능, ui 수정안됌
- [x]  필터링 커서포인터 넣기

clsoe #19 