### PR TITLE
[hotfix](#76): 페이지네이션 검증 오류 수정

### DIFF
--- a/src/app/(main)/creator/page.tsx
+++ b/src/app/(main)/creator/page.tsx
@@ -19,7 +19,7 @@ export default async function CreatorPage({ searchParams }: CreatorPageProps) {
   }
   const lecturesData = state.data;
 
-  if (isNaN(page) || page <= 0 || page > lecturesData.totalPages) {
+  if (isNaN(page) || page <= 0 || page - 1 > lecturesData.totalPages) {
     redirect('/creator');
   }
   return (

--- a/src/app/(main)/detail/[id]/page.tsx
+++ b/src/app/(main)/detail/[id]/page.tsx
@@ -40,7 +40,7 @@ export default async function LectureDetailPage({
   const lecture = lectureState.data!;
   const reviewData = reviewState.data!;
 
-  if (isNaN(page) || page <= 0 || page > reviewData.totalPages) {
+  if (isNaN(page) || page <= 0 || page - 1 > reviewData.totalPages) {
     redirect(`/detail/${id}`);
   }
 

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -57,7 +57,7 @@ export default async function MainPage({ searchParams }: PageProps) {
   const pageNumber = data.pageable.pageNumber + 1;
   const totalPages = data.totalPages;
 
-  if (isNaN(page) || page <= 0 || page > totalPages) {
+  if (isNaN(page) || page <= 0 || page - 1 > totalPages) {
     redirect(`/`);
   }
 


### PR DESCRIPTION
## 구현 결과

- [x] 메인 페이지, 상세 페이지, 강의 관리 페이지의 페이지네이션 검증 오류로, 아무 item이 없는 경우 무한 로딩되는 현상 수정

## 리뷰 필요

1. 각 페이지에서 아무 아이템이 없는 경우 무한 로딩이 발생하지 않는지 확인 필요

close #76 
