### PR TITLE
[hotfix](#78): 수강 페이지 유효 레슨 체크 오타 수정

### DIFF
--- a/src/app/play/[enrollmentId]/page.tsx
+++ b/src/app/play/[enrollmentId]/page.tsx
@@ -23,7 +23,7 @@ export default async function PlayPage({
   const { enrollmentId } = await params;
   const { lectureId, lessonId } = await searchParams;
 
-  if (!enrollmentId || !lectureId || !lectureId) {
+  if (!enrollmentId || !lectureId || !lessonId) {
     alert('수강 정보가 없습니다.');
     redirect('/mylearning');
   }


### PR DESCRIPTION
## 구현 결과

- [x] 수강 페이지에서 lessonId를 체크하지 않고, lectureId로 두 번 체크하던 오타 수정

## 리뷰 필요

x

close #78 
