### PR TITLE
refactor: 오답은 빨간색, 정답은 초록색으로 표시 ui 수정

### DIFF
--- a/src/features/learning/components/play/ButtonSubmit.tsx
+++ b/src/features/learning/components/play/ButtonSubmit.tsx
@@ -19,7 +19,9 @@ export function ButtonSubmit({
     <Button
       onClick={onClick}
       disabled={disabled}
-      className="bg-emerald-600 hover:bg-emerald-700 disabled:opacity-40 text-white font-bold px-8 py-6 text-lg cursor-pointer"
+      className="bg-emerald-600 hover:bg-emerald-700 disabled:opacity-40 disabled:cursor-not-allowed disabled:hover:bg-emerald-600
+        text-white font-bold px-8 py-6 text-lg
+      " //disabled일 때 커서/hover가 자연스럽게 보이도록 수정
     >
       {children} {/* ← 여기서 부모가 넘긴 '제출하기' / '제출 완료' 사용 */}
     </Button>

--- a/src/features/learning/components/play/Question.tsx
+++ b/src/features/learning/components/play/Question.tsx
@@ -1,4 +1,4 @@
-// src\features\learning\components\play\Question.tsx
+// src/features/learning/components/play/Question.tsx
 'use client';
 
 import { QuizQuestion } from '@/features/lectures/types';
@@ -8,7 +8,7 @@ interface QuestionProps {
   question: QuizQuestion;
   selected?: boolean;
   submitted: boolean;
-  correctAnswer?: boolean;
+  correctAnswer: boolean; // optional 말고 필수로 (Quiz에서 넘김)
   onSelect: (questionId: string, answer: boolean) => void;
 }
 
@@ -20,8 +20,7 @@ export function Question({
   correctAnswer,
   onSelect,
 }: QuestionProps) {
-  const isCorrect = submitted && selected === correctAnswer;
-  const isWrong = submitted && selected && selected !== correctAnswer;
+  const hasSelected = selected !== undefined; // false도 선택으로 인정
 
   return (
     <div className="p-6 rounded-lg transition-colors mb-0">
@@ -36,44 +35,52 @@ export function Question({
 
       <div className="flex gap-4 pl-12">
         {([true, false] as boolean[]).map((option, idx) => {
-          const isActive = selected === option;
+          const isActive = hasSelected && selected === option;
+
+          // 제출 후 채점 색상 규칙
+          const isCorrectOption = submitted && option === correctAnswer; // 정답 보기(항상 초록)
+          const isWrongSelected =
+            submitted && isActive && option !== correctAnswer; // 내가 고른 오답(빨강)
+
+          const base =
+            'flex-1 flex items-center justify-center gap-2 p-4 rounded-md border cursor-pointer transition-all group';
+
+          const normalState = isActive
+            ? 'border-emerald-500 bg-emerald-500/20'
+            : 'border-zinc-700';
+
+          const hoverState = !submitted
+            ? 'hover:bg-zinc-700/50 hover:border-emerald-500/50'
+            : '';
+
+          const gradingState = submitted
+            ? isCorrectOption
+              ? 'border-green-500 bg-green-500/20'
+              : isWrongSelected
+              ? 'border-red-500 bg-red-500/20'
+              : 'opacity-80'
+            : '';
 
           return (
             <label
               key={idx}
               onClick={() => onSelect(question.id, option)}
-              className={`
-                flex-1 flex items-center justify-center gap-2 p-4 rounded-md border
-                cursor-pointer transition-all group
-                ${
-                  isActive
-                    ? 'border-emerald-500 bg-emerald-500/20' /*  선택된 옵션 민트 */
-                    : 'border-zinc-700'
-                }
-                ${
-                  !submitted
-                    ? 'hover:bg-zinc-700/50 hover:border-emerald-500/50' /*  hover도 민트 */
-                    : ''
-                }
-                ${
-                  submitted && isActive && isWrong
-                    ? // ? 'border-red-500 bg-red-500/20'
-                      'border-green-500 bg-green-500/20' //정답 오답체크 기능 뺐으므로
-                    : ''
-                }
-                ${
-                  submitted && isActive && isCorrect
-                    ? 'border-green-500 bg-green-500/20'
-                    : ''
-                }
-              `}
+              className={`${base} ${normalState} ${hoverState} ${gradingState}`}
             >
               <input
                 type="radio"
                 name={`quiz-${question.id}`}
-                checked={isActive}
+                checked={!!isActive}
                 readOnly
-                className="w-4 h-4 accent-emerald-500" /*  동그라미 체크 색도 민트 */
+                className={`w-4 h-4 ${
+                  submitted
+                    ? isWrongSelected
+                      ? 'accent-red-500'
+                      : isCorrectOption
+                      ? 'accent-green-500'
+                      : 'accent-zinc-500'
+                    : 'accent-emerald-500'
+                }`}
               />
               <span className="text-xl font-bold text-zinc-300 group-hover:text-white">
                 {option ? 'O' : 'X'}

--- a/src/features/learning/components/play/Quiz.tsx
+++ b/src/features/learning/components/play/Quiz.tsx
@@ -21,7 +21,7 @@ export function Quiz({ enrollmentId, lesson }: QuizProps) {
 
   const questions = lesson.quizQuestions!;
 
-  // ✅ 현재 URL 정보 사용
+  // 현재 URL 정보 사용
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
@@ -95,6 +95,9 @@ export function Quiz({ enrollmentId, lesson }: QuizProps) {
               selected={selected[q.id]}
               onSelect={handleSelect}
               submitted={submitted}
+              correctAnswer={q.correct} //  추가: 정답 전달
+              // 각 질문의 정답을 자식 컴포넌트로 전달
+              // 정답/오답 표시용
             />
           ))}
         </div>


### PR DESCRIPTION
## 구현 결과
- [ ] 수강페이지 리팩토링 7번 (백엔드 작업완료후) → 레슨 정보 API 따로 빼는 작업
- [x] 수강 페이지 퀴즈 답 제출 시 정답 표시.
- [ ]  나갔다가 들어왔을 때 완료된 퀴즈면 제출하기 버튼 비활성화, 정답인 화면 표시

## 리뷰 필요

1. 수강 페이지 퀴즈 답 제출 시 정답 표시
