### PR TITLE
[fix](#89): 로그아웃 토큰 전달 방식 수정

### DIFF
--- a/src/services/auth.service.ts
+++ b/src/services/auth.service.ts
@@ -1,6 +1,7 @@
 // src/services/auth.service.ts
 
 import { commonFetch, authFetch } from '@/shared/api'; //  authFetch 추가
+import { cookies } from 'next/headers';
 
 async function login(user: { email: string; password: string }) {
   const response = await commonFetch(`/api/v1/auth/login`, {
@@ -18,8 +19,13 @@ async function getUser() {
 }
 
 async function logout() {
-  const response = await authFetch('/api/v1/auth/logout', {
+  const cookieStore = await cookies();
+  const refreshToken = cookieStore.get('refreshToken');
+  const response = await commonFetch('/api/v1/auth/logout', {
     method: 'POST',
+    headers: {
+      Cookie: `refresh_token=${refreshToken}`,
+    },
   });
   return response.json();
 }


### PR DESCRIPTION
## 구현 결과

- [x] 기존 authFetch 로직을 사용하던 logout 로직을 cookie에 리프레시 토큰을 넣어 commonFetch를 사용하도록 변경

## 리뷰 필요

1. 로그아웃시 오류가 나지 않는지 확인 필요

close #89 
