### PR TITLE
[feat](#121): 강의 관리 페이지 반려 툴팁 변경

### DIFF
--- a/src/features/creator/components/manage/LectureRow.tsx
+++ b/src/features/creator/components/manage/LectureRow.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { TableCell, TableRow } from '@/components/ui/table';
-import { Star } from 'lucide-react';
+import { CircleAlertIcon, Star } from 'lucide-react';
 import { Badge } from '@/components/ui/badge';
 import { AspectRatio } from '@/components/ui/aspect-ratio';
 import { CreatorLecture, LectureStatus } from '../../types';
@@ -83,19 +83,27 @@ export default function LectureRow({ lecture }: LectureRowProps) {
       }
       case 'REJECTED': {
         return (
-          <Tooltip>
-            <TooltipTrigger>
-              <Badge
-                variant="secondary"
-                className="w-16 border border-red-500 bg-red-500/10 text-red-500 cursor-pointer"
-              >
-                반려 됨
-              </Badge>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-              <p>반려 사유가 들어갈 자리</p>
-            </TooltipContent>
-          </Tooltip>
+          <div className="flex gap-1">
+            <Tooltip>
+              <TooltipTrigger>
+                <CircleAlertIcon className="text-red-500 cursor-pointer" />
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <p>반려 사유가 들어갈 자리</p>
+              </TooltipContent>
+            </Tooltip>
+            <Button
+              variant="outline"
+              onClick={handlePublish}
+              disabled={isPending}
+              className="group w-16 h-6 rounded-xl border-red-500 bg-red-500/10 text-red-500 hover:bg-whilte/10 hover:text-white hover:border-white text-xs cursor-pointer transition-all"
+            >
+              <span className="block group-hover:hidden">반려 됨</span>
+              <span className="hidden group-hover:block font-bold">
+                검토 요청
+              </span>
+            </Button>
+          </div>
         );
       }
     }


### PR DESCRIPTION
## 구현 결과

- [x] 강의 관리 페이지에서 반려됨 상태의 뱃지를 툴팁 아이콘과 검토 요청 버튼으로 분리

## 리뷰 필요

X

close #121 
