### PR TITLE
[feat](#135): confirm -> alert dialog로 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@radix-ui/react-accordion": "^1.2.12",
+    "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-aspect-ratio": "^1.1.8",
     "@radix-ui/react-avatar": "^1.1.11",
     "@radix-ui/react-checkbox": "^1.3.3",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import localFont from 'next/font/local';
 import UserInitializer from '@/features/auth/components/UserInitializer';
 import { getUserAction } from '@/features/auth/actions';
 import { Toaster } from '@/components/ui/sonner';
+import { ConfirmProvider } from '@/components/layout/ConfirmProvider';
 
 const pretendard = localFont({
   src: '../../public/fonts/PretendardVariable.woff2',
@@ -27,8 +28,8 @@ export default async function RootLayout({
         className={`${pretendard.variable} font-sans antialiased min-h-screen bg-background text-foreground`}
       >
         <UserInitializer user={user} />
-        {/* 모든 페이지(page.tsx) 내용을 여기에 렌더링. */}
         <Toaster position="top-center" />
+        <ConfirmProvider />
         {children}
       </body>
     </html>

--- a/src/components/layout/ConfirmProvider.tsx
+++ b/src/components/layout/ConfirmProvider.tsx
@@ -1,0 +1,56 @@
+// components/confirm-provider.tsx
+'use client';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/alert-dialog';
+import { useConfirmStore } from '@/store/confirmStore';
+
+export const ConfirmProvider = () => {
+  // 개별적으로 구독하여 불필요한 전체 리렌더링 방지
+  const isOpen = useConfirmStore((state) => state.isOpen);
+  const title = useConfirmStore((state) => state.title);
+  const description = useConfirmStore((state) => state.description);
+  const resolve = useConfirmStore((state) => state.resolve);
+  const close = useConfirmStore((state) => state.close);
+
+  const handleAction = (value: boolean) => {
+    resolve(value);
+    close();
+  };
+
+  return (
+    <AlertDialog
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          handleAction(false);
+        }
+      }}
+    >
+      <AlertDialogContent onOpenAutoFocus={(e) => e.preventDefault()}>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription className={!description ? 'sr-only' : ''}>
+            {description || title}
+          </AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel onClick={() => handleAction(false)}>
+            취소
+          </AlertDialogCancel>
+          <AlertDialogAction onClick={() => handleAction(true)} autoFocus>
+            확인
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  );
+};

--- a/src/components/ui/alert-dialog.tsx
+++ b/src/components/ui/alert-dialog.tsx
@@ -1,0 +1,157 @@
+"use client"
+
+import * as React from "react"
+import * as AlertDialogPrimitive from "@radix-ui/react-alert-dialog"
+
+import { cn } from "@/shared/utils/index"
+import { buttonVariants } from "@/components/ui/button"
+
+function AlertDialog({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Root>) {
+  return <AlertDialogPrimitive.Root data-slot="alert-dialog" {...props} />
+}
+
+function AlertDialogTrigger({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Trigger>) {
+  return (
+    <AlertDialogPrimitive.Trigger data-slot="alert-dialog-trigger" {...props} />
+  )
+}
+
+function AlertDialogPortal({
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Portal>) {
+  return (
+    <AlertDialogPrimitive.Portal data-slot="alert-dialog-portal" {...props} />
+  )
+}
+
+function AlertDialogOverlay({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Overlay>) {
+  return (
+    <AlertDialogPrimitive.Overlay
+      data-slot="alert-dialog-overlay"
+      className={cn(
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 fixed inset-0 z-50 bg-black/50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogContent({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Content>) {
+  return (
+    <AlertDialogPortal>
+      <AlertDialogOverlay />
+      <AlertDialogPrimitive.Content
+        data-slot="alert-dialog-content"
+        className={cn(
+          "bg-background data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 fixed top-[50%] left-[50%] z-50 grid w-full max-w-[calc(100%-2rem)] translate-x-[-50%] translate-y-[-50%] gap-4 rounded-lg border p-6 shadow-lg duration-200 sm:max-w-lg",
+          className
+        )}
+        {...props}
+      />
+    </AlertDialogPortal>
+  )
+}
+
+function AlertDialogHeader({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-header"
+      className={cn("flex flex-col gap-2 text-center sm:text-left", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogFooter({
+  className,
+  ...props
+}: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="alert-dialog-footer"
+      className={cn(
+        "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogTitle({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Title>) {
+  return (
+    <AlertDialogPrimitive.Title
+      data-slot="alert-dialog-title"
+      className={cn("text-lg font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogDescription({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Description>) {
+  return (
+    <AlertDialogPrimitive.Description
+      data-slot="alert-dialog-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogAction({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Action>) {
+  return (
+    <AlertDialogPrimitive.Action
+      className={cn(buttonVariants(), className)}
+      {...props}
+    />
+  )
+}
+
+function AlertDialogCancel({
+  className,
+  ...props
+}: React.ComponentProps<typeof AlertDialogPrimitive.Cancel>) {
+  return (
+    <AlertDialogPrimitive.Cancel
+      className={cn(buttonVariants({ variant: "outline" }), className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  AlertDialog,
+  AlertDialogPortal,
+  AlertDialogOverlay,
+  AlertDialogTrigger,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogFooter,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogAction,
+  AlertDialogCancel,
+}

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -3,7 +3,7 @@ import * as React from 'react';
 import { Slot } from '@radix-ui/react-slot';
 import { cva, type VariantProps } from 'class-variance-authority';
 
-import { cn } from '@/shared/utils';
+import { cn } from '@/shared/utils/index';
 
 const buttonVariants = cva(
   "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",

--- a/src/features/audit/components/detail/AuditAcceptButton.tsx
+++ b/src/features/audit/components/detail/AuditAcceptButton.tsx
@@ -5,6 +5,7 @@ import { useRouter } from 'next/navigation';
 import { Button } from '@/components/ui/button';
 import { toast } from 'sonner';
 import { approveAuditAction } from '@/features/audit/actions';
+import { useConfirm } from '@/hooks/useConfirm';
 
 interface AuditAcceptButtonProps {
   lectureId: number;
@@ -14,12 +15,11 @@ export default function AuditAcceptButton({
   lectureId,
 }: AuditAcceptButtonProps) {
   const router = useRouter();
-
+  const confirm = useConfirm();
   const onApprove = async () => {
-    const confirmed = confirm('강의를 승인하시겠습니까?');
+    const confirmed = await confirm('강의를 승인하시겠습니까?');
     if (!confirmed) return;
 
-    // ✅ string 변환 제거
     const state = await approveAuditAction(lectureId);
 
     if (!state.success) {

--- a/src/features/creator/components/form/ChapterItem.tsx
+++ b/src/features/creator/components/form/ChapterItem.tsx
@@ -13,6 +13,7 @@ import {
 } from '../../actions';
 import LessonItem from './LessonItem';
 import { toast } from 'sonner';
+import { useConfirm } from '@/hooks/useConfirm';
 
 interface ChapterItemProps {
   lectureId: number;
@@ -47,6 +48,7 @@ export default function ChapterItem({
   registerOpenLesson,
   unregisterOpenLesson,
 }: ChapterItemProps) {
+  const confirm = useConfirm();
   const [isPending, startTransition] = useTransition();
   const chapterTitleRef = useRef('');
   const { register, control, watch, setValue } =
@@ -102,8 +104,12 @@ export default function ChapterItem({
     });
   };
 
-  const handleDeleteChapter = () => {
-    if (!confirm('챕터를 삭제하시겠습니까? 하위 레슨도 삭제됩니다.')) {
+  const handleDeleteChapter = async () => {
+    const ok = await confirm(
+      '챕터를 삭제하시겠습니까?',
+      '하위 레슨도 삭제됩니다.',
+    );
+    if (!ok) {
       return;
     }
     if (!chapterId) {

--- a/src/features/creator/components/form/LessonItem.tsx
+++ b/src/features/creator/components/form/LessonItem.tsx
@@ -23,6 +23,7 @@ import {
 import { toast } from 'sonner';
 import QuizItem from './QuizItem';
 import VideoItem from './VideoItem';
+import { useConfirm } from '@/hooks/useConfirm';
 
 interface LessonItemProps {
   lectureId: number;
@@ -43,6 +44,7 @@ export default function LessonItem({
   registerOpenLesson,
   unregisterOpenLesson,
 }: LessonItemProps) {
+  const confirm = useConfirm();
   const { register, watch, setValue, getValues, control } =
     useFormContext<CurriculumFormValues>();
   const [isOpen, setIsOpen] = useState(true);
@@ -131,14 +133,18 @@ export default function LessonItem({
     });
   };
 
-  const handleDeleteLesson = () => {
+  const handleDeleteLesson = async () => {
     if (!lessonId) {
       toast.error('존재하지 않는 레슨입니다.');
       removeLesson();
       return;
     }
 
-    if (!confirm('레슨을 삭제하시겠습니까?')) return;
+    const ok = await confirm(
+      '레슨을 삭제하시겠습니까?',
+      '레슨이 영구적으로 삭제됩니다.',
+    );
+    if (!ok) return;
 
     startTransition(async () => {
       const state = await deleteLessonAction(lectureId, lessonId);

--- a/src/features/creator/components/manage/LectureDropdown.tsx
+++ b/src/features/creator/components/manage/LectureDropdown.tsx
@@ -13,6 +13,7 @@ import { useRouter } from 'next/navigation';
 import { useTransition } from 'react';
 import { deleteCreatorLectureAction } from '../../actions';
 import { toast } from 'sonner';
+import { useConfirm } from '@/hooks/useConfirm';
 
 interface LectureDropdownProps {
   lectureId: number;
@@ -23,6 +24,7 @@ export default function LectureDropdown({
   lectureId,
   lectureTitle,
 }: LectureDropdownProps) {
+  const confirm = useConfirm();
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
@@ -30,8 +32,9 @@ export default function LectureDropdown({
     router.push(`creator/${lectureId}?step=1`);
   };
 
-  const handleDelete = () => {
-    if (confirm(`${lectureTitle} 강의를 정말 삭제하시겠습니까?`)) {
+  const handleDelete = async () => {
+    const ok = await confirm(`${lectureTitle} 강의를 정말 삭제하시겠습니까?`);
+    if (ok) {
       startTransition(async () => {
         const state = await deleteCreatorLectureAction(lectureId);
         if (state.success) {

--- a/src/features/creator/components/manage/LectureRow.tsx
+++ b/src/features/creator/components/manage/LectureRow.tsx
@@ -19,21 +19,23 @@ import {
 import { Textarea } from '@/components/ui/textarea';
 import { Separator } from '@/components/ui/separator';
 import { toast } from 'sonner';
+import { useConfirm } from '@/hooks/useConfirm';
 
 interface LectureRowProps {
   lecture: CreatorLecture;
 }
 
 export default function LectureRow({ lecture }: LectureRowProps) {
+  const confirm = useConfirm();
   const router = useRouter();
   const [isPending, startTransition] = useTransition();
 
-  const handlePublish = () => {
-    if (
-      !confirm(
-        `${lecture.title} 강의 검토를 신청하시겠습니까? 검토가 시작되면 강의 내용을 수정하실 수 없으며 공개된 후에는 강의를 삭제할 수 없습니다.`,
-      )
-    ) {
+  const handlePublish = async () => {
+    const ok = await confirm(
+      `${lecture.title} 강의 검토를 신청하시겠습니까?`,
+      '검토가 시작되면 강의 내용을 수정하실 수 없으며 공개된 후에는 강의를 삭제할 수 없습니다.',
+    );
+    if (!ok) {
       return;
     }
     startTransition(async () => {

--- a/src/hooks/useConfirm.ts
+++ b/src/hooks/useConfirm.ts
@@ -1,0 +1,7 @@
+// hooks/use-confirm.ts
+import { useConfirmStore } from '@/store/confirmStore';
+
+export const useConfirm = () => {
+  const confirm = useConfirmStore((state) => state.confirm);
+  return confirm;
+};

--- a/src/hooks/useUser.ts
+++ b/src/hooks/useUser.ts
@@ -1,0 +1,7 @@
+// 임시 생성(사용x)
+import { useUserStore } from '@/store/userStore';
+
+export const useUser = () => {
+  const confirm = useUserStore((state) => state.user);
+  return confirm;
+};

--- a/src/store/confirmStore.ts
+++ b/src/store/confirmStore.ts
@@ -1,0 +1,25 @@
+// store/use-confirm-store.ts
+import { create } from 'zustand';
+
+interface ConfirmState {
+  isOpen: boolean;
+  title: string;
+  description: string;
+  resolve: (value: boolean) => void;
+  confirm: (title: string, description?: string) => Promise<boolean>;
+  close: () => void;
+}
+
+export const useConfirmStore = create<ConfirmState>((set) => ({
+  isOpen: false,
+  title: '',
+  description: '',
+  resolve: () => {},
+  confirm: (title, description = '') => {
+    set({ isOpen: true, title, description });
+    return new Promise((resolve) => {
+      set({ resolve });
+    });
+  },
+  close: () => set({ isOpen: false }),
+}));


### PR DESCRIPTION
## 구현 결과

- [x] window confirm 대신 shadcn alert dialog로 대체

## 리뷰 필요

1. confirm 대신 잘 작동하는지 리뷰 필요
2. npm install 필요

close #135 
